### PR TITLE
Scalable dividends

### DIFF
--- a/contracts/BondingCurve/dividend/RewardsDistributor.sol
+++ b/contracts/BondingCurve/dividend/RewardsDistributor.sol
@@ -42,10 +42,10 @@ contract RewardsDistributor {
     mapping(address => int256) _rewardOffset;
 
 
-    event DepositMade(address indexed _from, uint256 value);
-    event DistributionMade(address indexed _from, uint256 value);
-    event RewardWithdrawalMade(address indexed _to, uint256 value);
-    event StakeWithdrawalMade(address indexed _to, uint256 value);
+    event DepositMade(address indexed from, uint256 value);
+    event DistributionMade(uint256 value);
+    event RewardWithdrawalMade(address indexed to, uint256 value);
+    event StakeWithdrawalMade(address indexed to, uint256 value);
 
 
     /// Initialize the contract.
@@ -97,7 +97,7 @@ contract RewardsDistributor {
         // increase total rewards per stake unit
         _rewardTotal = _rewardTotal.add(_ratio);
 
-        emit DistributionMade(msg.sender, tokens);
+        emit DistributionMade(tokens);
         return true;
     }
 
@@ -150,7 +150,7 @@ contract RewardsDistributor {
 
     /// @notice Read total stake.
     function getStakeTotal() public returns (uint256) {
-        return _stakeTotal;
+        return _stakeTotal.mul(ELIGIBLE_UNIT);
     }
 
 

--- a/contracts/BondingCurve/dividend/RewardsDistributor.sol
+++ b/contracts/BondingCurve/dividend/RewardsDistributor.sol
@@ -1,0 +1,176 @@
+
+pragma solidity ^0.5.6;
+
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+
+
+/// @title RewardsDistributor - Distribute pro rata rewards (dividends)
+/// @author Bogdan Batog (https://batog.info)
+/// @dev Distribute pro rata rewards (dividends) to token holders in O(1) time.
+///      Based on http://batog.info/papers/scalable-reward-distribution.pdf
+///      And on https://solmaz.io/2019/02/24/scalable-reward-changing/
+contract RewardsDistributor {
+    using SafeMath for uint256;
+
+    /// @notice ELIGIBLE_UNIT is the smallest eligible unit for reward. Minimum
+    ///  possible distribution is 1 (wei for Ether) PER ELIGIBLE_UNIT.
+    ///
+    ///  Only multiple of ELIGIBLE_UNIT will be subject to reward
+    ///  distribution. Any fractional part of deposit, smaller than
+    ///  ELIGIBLE_UNIT, won't receive any reward.
+    ///
+    ///  Recommended value 10**(decimals / 2), that is 10**9 for most ERC20.
+    uint256 public ELIGIBLE_UNIT = 10**9;
+
+    /// @notice Stake per address.
+    mapping(address => uint256) stake;
+
+    /// @notice Stake reminder per address.
+    mapping(address => uint256) stakeReminder;
+
+    /// @notice Total staked tokens. In ELIGIBLE_UNIT units.
+    uint256 public stakeTotal;
+
+    /// @notice Total reward since the beginning of time, in units per
+    ///  ELIGIBLE_UNIT.
+    uint256 rewardTotal;
+
+    /// @notice Reminder from the last reward distribution.
+    uint256 rewardRemainder;
+
+    /// @notice Proportional rewards awarded *before* this stake was created.
+    mapping(address => int256) rewardOffset;
+
+
+    event DepositMade(address _from, uint value);
+    event DistributionMade(address _from, uint value);
+    event RewardWithdrawalMade(address _to, uint value);
+    event StakeWithdrawalMade(address _to, uint value);
+
+
+    /// Initialize the contract.
+    constructor() public {
+        stakeTotal = 0;
+        rewardTotal = 0;
+        rewardRemainder = 0;
+    }
+
+
+    /// @notice Deposit funds into contract.
+    function _deposit(address staker, uint256 tokens) internal returns (bool success) {
+
+        uint256 _tokensToAdd = tokens.add(stakeReminder[staker]);
+
+        uint256 _eligibleUnitsToAdd = _tokensToAdd.div(ELIGIBLE_UNIT);
+
+        // update the new reminder for this address
+        stakeReminder[staker] = _tokensToAdd.mod(ELIGIBLE_UNIT);
+
+        // set the current stake for this address
+        stake[staker] = stake[staker].add(_eligibleUnitsToAdd);
+
+        // update total eligible stake units
+        stakeTotal = stakeTotal.add(_eligibleUnitsToAdd);
+
+        // update reward offset
+        rewardOffset[staker] += (int256)(rewardTotal * _eligibleUnitsToAdd);
+
+        emit DepositMade(staker, tokens);
+        return true;
+    }
+
+
+    /// @notice Distribute tokens pro rata to all stakers.
+    function _distribute(uint tokens) internal returns (bool success) {
+        require(tokens > 0);
+        require(stakeTotal > 0);
+
+        // add past distribution reminder
+        uint256 _amountToDistribute = tokens.add(rewardRemainder);
+
+        // determine rewards per eligible stake
+        uint256 _ratio = _amountToDistribute.div(stakeTotal);
+
+        // carry on reminder
+        rewardRemainder = _amountToDistribute.mod(stakeTotal);
+
+        // increase total rewards per stake unit
+        rewardTotal = rewardTotal.add(_ratio);
+
+        emit DistributionMade(msg.sender, tokens);
+        return true;
+    }
+
+
+    /// @notice Withdraw accumulated reward for the staker address.
+    function _withdrawReward(address staker) internal returns (uint256 tokens) {
+
+        uint256 _reward = getReward(staker);
+
+        // refresh reward offset (so a new call to getReward returns 0)
+        rewardOffset[staker] = (int256) (rewardTotal.mul(stake[staker]));
+
+        emit RewardWithdrawalMade(staker, _reward);
+        return _reward;
+    }
+
+
+    /// @notice Withdraw stake for the staker address
+    function _withdrawStake(address staker, uint256 tokens) internal returns (bool) {
+
+        uint256 _currentStake = getStake(staker);
+
+        require(tokens <= _currentStake);
+
+        // update stake and reminder for this address
+        uint256 _newStake = _currentStake.sub(tokens);
+
+        stakeReminder[staker] = _newStake.mod(ELIGIBLE_UNIT);
+
+        uint256 _eligibleUnitsDelta = stake[staker].sub(
+            _newStake.div(ELIGIBLE_UNIT)
+        );
+
+        stake[staker] = stake[staker].sub(_eligibleUnitsDelta);
+
+        // update total stake
+        stakeTotal = stakeTotal.sub(_eligibleUnitsDelta);
+
+        // update reward offset
+        rewardOffset[staker] -= (int256) (rewardTotal.mul(_eligibleUnitsDelta));
+
+        emit StakeWithdrawalMade(staker, tokens);
+        return true;
+    }
+
+    ///
+    /// READ ONLY
+    ///
+
+    /// @notice Read current stake for address.
+    function getStake(address staker) public view returns (uint256 tokens) {
+        tokens = (
+            stake[staker].mul(ELIGIBLE_UNIT)
+        ).add(
+            stakeReminder[staker]
+        );
+
+        return tokens;
+    }
+
+
+    /// @notice Read current accumulated reward for address.
+    function getReward(address staker) public view returns (uint256 tokens) {
+        int256 _tokens = (
+            (int256)(
+                stake[staker].mul(rewardTotal)
+            ) - rewardOffset[staker]
+        );
+
+        tokens = (uint256) (_tokens);
+
+        return tokens;
+    }
+
+}
+

--- a/contracts/BondingCurve/dividend/RewardsDistributor.sol
+++ b/contracts/BondingCurve/dividend/RewardsDistributor.sol
@@ -27,8 +27,8 @@ contract RewardsDistributor {
     /// @notice Stake per address.
     mapping(address => uint256) internal _stake;
 
-    /// @notice Stake reminder per address, smaller than ELIGIBLE_UNIT.
-    mapping(address => uint256) internal _stakeReminder;
+    /// @notice Stake remainder per address, smaller than ELIGIBLE_UNIT.
+    mapping(address => uint256) internal _stakeRemainder;
 
     /// @notice Total staked tokens. In ELIGIBLE_UNIT units.
     uint256 internal _stakeTotal;
@@ -37,7 +37,7 @@ contract RewardsDistributor {
     /// per ELIGIBLE_UNIT.
     uint256 internal _rewardTotal;
 
-    /// @notice Reminder from the last _distribute() call, this amount was not
+    /// @notice Remainder from the last _distribute() call, this amount was not
     /// enough to award at least 1 wei to every staked ELIGIBLE_UNIT. At the
     /// time of last _distribute() call _rewardRemainder < _stakeTotal.
     /// Note that later, _stakeTotal can decrease, but _rewardRemainder will
@@ -66,12 +66,12 @@ contract RewardsDistributor {
     /// @notice Deposit funds into contract.
     function _deposit(address staker, uint256 tokens) internal returns (bool success) {
 
-        uint256 _tokensToAdd = tokens.add(_stakeReminder[staker]);
+        uint256 _tokensToAdd = tokens.add(_stakeRemainder[staker]);
 
         uint256 _eligibleUnitsToAdd = _tokensToAdd.div(ELIGIBLE_UNIT);
 
-        // update the new reminder for this address
-        _stakeReminder[staker] = _tokensToAdd.mod(ELIGIBLE_UNIT);
+        // update the new remainder for this address
+        _stakeRemainder[staker] = _tokensToAdd.mod(ELIGIBLE_UNIT);
 
         // set the current stake for this address
         _stake[staker] = _stake[staker].add(_eligibleUnitsToAdd);
@@ -92,13 +92,13 @@ contract RewardsDistributor {
         require(tokens > 0);
         require(_stakeTotal > 0);
 
-        // add past distribution reminder
+        // add past distribution remainder
         uint256 _amountToDistribute = tokens.add(_rewardRemainder);
 
         // determine rewards per eligible stake
         uint256 _ratio = _amountToDistribute.div(_stakeTotal);
 
-        // carry on reminder
+        // carry on remainder
         _rewardRemainder = _amountToDistribute.mod(_stakeTotal);
 
         // increase total rewards per stake unit
@@ -129,10 +129,10 @@ contract RewardsDistributor {
 
         require(tokens <= _currentStake);
 
-        // update stake and reminder for this address
+        // update stake and remainder for this address
         uint256 _newStake = _currentStake.sub(tokens);
 
-        _stakeReminder[staker] = _newStake.mod(ELIGIBLE_UNIT);
+        _stakeRemainder[staker] = _newStake.mod(ELIGIBLE_UNIT);
 
         uint256 _eligibleUnitsDelta = _stake[staker].sub(
             _newStake.div(ELIGIBLE_UNIT)
@@ -166,7 +166,7 @@ contract RewardsDistributor {
         tokens = (
             _stake[staker].mul(ELIGIBLE_UNIT)
         ).add(
-            _stakeReminder[staker]
+            _stakeRemainder[staker]
         );
 
         return tokens;

--- a/contracts/BondingCurve/dividend/RewardsDistributor.sol
+++ b/contracts/BondingCurve/dividend/RewardsDistributor.sol
@@ -43,7 +43,7 @@ contract RewardsDistributor {
 
 
     event DepositMade(address indexed from, uint256 value);
-    event DistributionMade(uint256 value);
+    event DistributionMade(address indexed from, uint256 value);
     event RewardWithdrawalMade(address indexed to, uint256 value);
     event StakeWithdrawalMade(address indexed to, uint256 value);
 
@@ -81,7 +81,7 @@ contract RewardsDistributor {
 
 
     /// @notice Distribute tokens pro rata to all stakers.
-    function _distribute(uint tokens) internal returns (bool success) {
+    function _distribute(address from, uint tokens) internal returns (bool success) {
         require(tokens > 0);
         require(_stakeTotal > 0);
 
@@ -97,7 +97,7 @@ contract RewardsDistributor {
         // increase total rewards per stake unit
         _rewardTotal = _rewardTotal.add(_ratio);
 
-        emit DistributionMade(tokens);
+        emit DistributionMade(from, tokens);
         return true;
     }
 

--- a/contracts/BondingCurve/dividend/RewardsDistributorWrapper.sol
+++ b/contracts/BondingCurve/dividend/RewardsDistributorWrapper.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.5.6;
+
+import "./RewardsDistributor.sol";
+
+
+/// @title RewardsDistributorWrapper
+/// @author Bogdan Batog (https://batog.info)
+/// @dev ONLY FOR TESTING. DO NOT DEPLOY THIS!!!!!
+contract RewardsDistributorWrapper is RewardsDistributor {
+
+    /// @notice Deposit funds into contract.
+    function deposit(address staker, uint tokens) public returns (bool success) {
+        return _deposit(staker, tokens);
+    }
+
+    /// @notice Distribute tokens pro rata to all stakers.
+    function distribute(uint tokens) public returns (bool success) {
+        return _distribute(tokens);
+    }
+
+    /// @notice Withdraw accumulated reward for the staker address.
+    function withdrawReward(address staker) public returns (uint tokens) {
+        return _withdrawReward(staker);
+    }
+
+    /// @notice Withdraw all stake for the staker address.
+    function withdrawAllStake(address staker) public returns (uint tokens) {
+        tokens = getStake(staker);
+        _withdrawStake(staker, tokens);
+
+        return tokens;
+    }
+
+    /// @notice Withdraw stake for the staker address.
+    function withdrawStake(address staker, uint tokens) public returns (bool success) {
+        return _withdrawStake(staker, tokens);
+    }
+}
+

--- a/contracts/BondingCurve/dividend/RewardsDistributorWrapper.sol
+++ b/contracts/BondingCurve/dividend/RewardsDistributorWrapper.sol
@@ -15,7 +15,7 @@ contract RewardsDistributorWrapper is RewardsDistributor {
 
     /// @notice Distribute tokens pro rata to all stakers.
     function distribute(uint tokens) public returns (bool success) {
-        return _distribute(tokens);
+        return _distribute(address(0), tokens);
     }
 
     /// @notice Withdraw accumulated reward for the staker address.

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const DividendPool = Contracts.getFromLocal('DividendPool');
 const BondingCurve = Contracts.getFromLocal('BondingCurve');
 const BondingCurveFactory = Contracts.getFromLocal('BondingCurveFactory');
 const BondedToken = Contracts.getFromLocal('BondedToken');
+const RewardsDistributorWrapper = Contracts.getFromLocal('RewardsDistributorWrapper');
 
 const CONTRACT_ABIS = {
   BondingCurve,
@@ -20,7 +21,8 @@ const CONTRACT_ABIS = {
   StaticCurveLogic,
   BondedToken,
   DividendPool,
-  BancorCurveService
+  BancorCurveService,
+  RewardsDistributorWrapper
 };
 
 const CONTRACT_NAMES = {
@@ -30,7 +32,8 @@ const CONTRACT_NAMES = {
   StaticCurveLogic: 'StaticCurveLogic',
   BondedToken: 'BondedToken',
   DividendPool: 'DividendPool',
-  BancorCurveService: 'BancorCurveService'
+  BancorCurveService: 'BancorCurveService',
+  RewardsDistributorWrapper: 'RewardsDistributorWrapper'
 };
 
 const PACKAGE_NAMES = {
@@ -55,6 +58,7 @@ async function setupApp(txParams) {
   await appProject.setImplementation(BondedToken, CONTRACT_NAMES.BondedToken);
   await appProject.setImplementation(DividendPool, CONTRACT_NAMES.DividendPool);
   await appProject.setImplementation(BancorCurveService, CONTRACT_NAMES.BancorCurveService);
+  await appProject.setImplementation(RewardsDistributor, CONTRACT_NAMES.RewardsDistributor);
 
   return appProject;
 }
@@ -166,6 +170,15 @@ async function deployStandaloneERC20(myProject, initArgs) {
   //   });
 }
 
+async function deployRewardsDistributorWrapper(myProject, initArgs) {
+  ZWeb3.initialize(web3.currentProvider);
+
+  const instance = await myProject.createProxy(RewardsDistributorWrapper, {
+    initArgs
+  });
+  return instance;
+}
+
 async function getImplementation(project, contractName) {
   const directory = await project.getCurrentDirectory();
   const implementation = await directory.getImplementation(contractName);
@@ -203,6 +216,7 @@ module.exports = {
   deployBondingCurveFactory,
   deployBondedToken,
   deployStandaloneERC20,
+  deployRewardsDistributorWrapper,
   CONTRACT_NAMES,
   CONTRACT_ABIS,
   getImplementation,

--- a/test/unit/rewardDistributor.spec.ts
+++ b/test/unit/rewardDistributor.spec.ts
@@ -1,0 +1,52 @@
+// Import all required modules from openzeppelin-test-helpers
+const {BN, constants, expectEvent, expectRevert} = require('openzeppelin-test-helpers');
+
+// Import preferred chai flavor: both expect and should are supported
+const expect = require('chai').expect;
+const should = require('chai').should();
+
+require('../setup');
+const {deployProject, deployRewardsDistributorWrapper} = require('../../index.js');
+
+var TEN18 = new BN(String(10**18))
+
+var PPB = new BN(String(10**9))
+
+
+contract('RewardsDistributorWrapper', accounts => {
+  let tx;
+  let project;
+
+  const creator = accounts[0];
+  const initializer = accounts[1];
+
+  beforeEach(async function() {
+    project = await deployProject();
+    rd = await deployRewardsDistributorWrapper(project);
+  });
+
+  it("deploys and initializes", async function() {
+    let stakeTotal = await rd.methods.getStakeTotal().call({from: initializer});
+    assert.equal(stakeTotal, 0, "stakeTotal is NOT zero!");
+  });
+
+  it("deposit A, getStake, withdrawAllStake, getStake", async function() {
+    var acct_a = accounts[1];
+
+    var amount = (new BN("100")).mul(TEN18);
+
+    let r1 = await rd.methods.deposit(acct_a, amount.toString()).call({from: acct_a});
+    expect(r1).to.be.equal(true);
+
+    let stakeTotal = await rd.methods.getStakeTotal().call({from: initializer});
+    expect(new BN(stakeTotal)).to.be.bignumber.equal(amount);
+
+    let stake = await rd.methods.getStake(acct_a).call({from: acct_a});
+    expect(new BN(stake)).to.be.bignumber.equal(amount);
+
+    await rd.methods.withdrawAllStake().call({from: acct_a});
+    let _stakeFinal = await rd.methods.getStake(acct_a).call({from: acct_a});
+    expect(new BN(stakeTotal)).to.be.bignumber.equal(0);
+  });
+
+})

--- a/test/unit/rewardDistributor.spec.ts
+++ b/test/unit/rewardDistributor.spec.ts
@@ -1,21 +1,24 @@
 // Import all required modules from openzeppelin-test-helpers
-const {BN, constants, expectEvent, expectRevert} = require('openzeppelin-test-helpers');
+const {BN, constants, expectRevert} = require('openzeppelin-test-helpers');
 
 // Import preferred chai flavor: both expect and should are supported
 const expect = require('chai').expect;
 const should = require('chai').should();
+const expectEvent = require('../expectEvent');
 
 require('../setup');
+
 const {deployProject, deployRewardsDistributorWrapper} = require('../../index.js');
 
-var TEN18 = new BN(String(10**18))
+var TEN18 = new BN(String(10 ** 18));
 
-var PPB = new BN(String(10**9))
-
+var PPB = new BN(String(10 ** 9));
 
 contract('RewardsDistributorWrapper', accounts => {
-  let tx;
   let project;
+  let rd;
+  let tx;
+  let ELIGIBLE_UNIT;
 
   const creator = accounts[0];
   const initializer = accounts[1];
@@ -23,30 +26,61 @@ contract('RewardsDistributorWrapper', accounts => {
   beforeEach(async function() {
     project = await deployProject();
     rd = await deployRewardsDistributorWrapper(project);
+    ELIGIBLE_UNIT = rd.ELIGIBLE_UNIT;
   });
 
-  it("deploys and initializes", async function() {
+  it('deploys and initializes', async function() {
     let stakeTotal = await rd.methods.getStakeTotal().call({from: initializer});
-    assert.equal(stakeTotal, 0, "stakeTotal is NOT zero!");
+    expect(new BN(stakeTotal)).to.be.bignumber.equal(new BN(0));
   });
 
-  it("deposit A, getStake, withdrawAllStake, getStake", async function() {
+  it('accepts deposit A, gets stake, withdraws all stake, gets stake again', async function() {
     var acct_a = accounts[1];
+    var amount = new BN('100').mul(TEN18);
 
-    var amount = (new BN("100")).mul(TEN18);
+    tx = await rd.methods
+      .deposit(acct_a, amount.toString())
+      .send({from: acct_a});
 
-    let r1 = await rd.methods.deposit(acct_a, amount.toString()).call({from: acct_a});
-    expect(r1).to.be.equal(true);
-
-    let stakeTotal = await rd.methods.getStakeTotal().call({from: initializer});
-    expect(new BN(stakeTotal)).to.be.bignumber.equal(amount);
+    expectEvent.inLogs(tx.events, 'DepositMade', {
+      _from: acct_a,
+      value: amount
+    });
 
     let stake = await rd.methods.getStake(acct_a).call({from: acct_a});
     expect(new BN(stake)).to.be.bignumber.equal(amount);
 
-    await rd.methods.withdrawAllStake().call({from: acct_a});
-    let _stakeFinal = await rd.methods.getStake(acct_a).call({from: acct_a});
-    expect(new BN(stakeTotal)).to.be.bignumber.equal(0);
+    await rd.methods.withdrawAllStake(acct_a).send({from: acct_a});
+
+    let stakeFinal = await rd.methods.getStake(acct_a).call({from: acct_a});
+    expect(new BN(stakeFinal)).to.be.bignumber.equal(new BN(0));
   });
 
-})
+  it('deposit A, distribute, getReward, withdrawReward and getReward', async function() {
+    var acct_a = accounts[1];
+    var amountDeposit = new BN('100').mul(TEN18);
+    var amountDistribute = new BN('200').mul(TEN18);
+
+    await rd.methods.deposit(acct_a, amountDeposit.toString()).send({from: acct_a});
+
+    tx = await rd.methods.distribute(amountDistribute.toString()).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'DistributionMade', {
+      _from: acct_a,
+      value: amountDistribute
+    });
+
+    // all reward is allocated to the single staker
+    var currentReward = await rd.methods.getReward(acct_a).call({from: acct_a});
+    expect(new BN(currentReward)).to.be.bignumber.equal(amountDistribute);
+
+    tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      _from: acct_a,
+      value: amountDistribute
+    });
+
+    currentReward = await rd.methods.getReward(acct_a).call({from: acct_a});
+    expect(new BN(currentReward)).to.be.bignumber.equal(new BN(0));
+  });
+    
+});

--- a/test/unit/rewardDistributor.spec.ts
+++ b/test/unit/rewardDistributor.spec.ts
@@ -20,8 +20,10 @@ contract('RewardsDistributorWrapper', accounts => {
   let tx;
   let ELIGIBLE_UNIT;
 
-  const creator = accounts[0];
-  const initializer = accounts[1];
+  let acct_a = accounts[1];
+  let acct_b = accounts[2];
+  let acct_c = accounts[3];
+  let acct_d = accounts[4];
 
   beforeEach(async function() {
     project = await deployProject();
@@ -30,29 +32,32 @@ contract('RewardsDistributorWrapper', accounts => {
   });
 
   it('deploys and initializes', async function() {
-    let stakeTotal = await rd.methods.getStakeTotal().call({from: initializer});
-    expect(new BN(stakeTotal)).to.be.bignumber.equal(new BN(0));
+    expect(
+      await rd.methods.getStakeTotal().call({from: acct_a})
+    ).to.be.equal('0');
   });
 
   it("withdraws ZERO reward", async function() {
-    var acct_a = accounts[1];
-
     tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
     expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
-      _from: acct_a,
+      to: acct_a,
       value: new BN('0')
     });
   });
 
   it("reads ZERO stake", async function() {
-    var acct_a = accounts[1];
-
-    let stake = await rd.methods.getStake(acct_a).call({from: acct_a});
-    expect(new BN(stake)).to.be.bignumber.equal(new BN('0'));
+    expect(
+      await rd.methods.getStake(acct_a).call({from: acct_a})
+    ).to.be.equal('0');
   });
 
-  it('deposits A, gets stake, withdraws all stake, gets stake again', async function() {
-    var acct_a = accounts[1];
+  it("reverts if trying to withdraw amount > stake", async function() {
+    await expectRevert.unspecified(
+      rd.methods.withdrawStake(acct_a, '1').send({from: acct_a})
+    );
+  });
+
+  it('updates total stake after deposit > ELIGIBLE_UNIT', async function() {
     var amount = new BN('100').mul(TEN18);
 
     tx = await rd.methods
@@ -60,21 +65,83 @@ contract('RewardsDistributorWrapper', accounts => {
       .send({from: acct_a});
 
     expectEvent.inLogs(tx.events, 'DepositMade', {
-      _from: acct_a,
+      from: acct_a,
       value: amount
     });
 
-    let stake = await rd.methods.getStake(acct_a).call({from: acct_a});
-    expect(new BN(stake)).to.be.bignumber.equal(amount);
+    expect(
+      await rd.methods.getStakeTotal().call({from: acct_a})
+    ).to.be.equal(amount.toString());
+  });
+
+  it('doesn\'t update total stake after deposit < ELIGIBLE_UNIT', async function() {
+    var amount = new BN('100');
+
+    tx = await rd.methods
+      .deposit(acct_a, amount.toString())
+      .send({from: acct_a});
+
+    expect(
+      await rd.methods.getStakeTotal().call({from: acct_a})
+    ).to.be.equal('0');
+  });
+
+  it('deposits A, gets stake, withdraws all stake, gets stake again', async function() {
+    var amount = new BN('100').mul(TEN18);
+
+    tx = await rd.methods
+      .deposit(acct_a, amount.toString())
+      .send({from: acct_a});
+
+    expect(
+      await rd.methods.getStake(acct_a).call({from: acct_a})
+    ).to.be.equal(amount.toString());
 
     await rd.methods.withdrawAllStake(acct_a).send({from: acct_a});
 
-    let stakeFinal = await rd.methods.getStake(acct_a).call({from: acct_a});
-    expect(new BN(stakeFinal)).to.be.bignumber.equal(new BN(0));
+    expect(
+      await rd.methods.getStake(acct_a).call({from: acct_a})
+    ).to.be.equal('0');
   });
 
-  it('deposits A, distributes, gets Reward, withdraws Reward and gets Reward', async function() {
-    var acct_a = accounts[1];
+  it("does no distribution if no stake >= ELIGIBLE_UNIT", async function() {
+    await rd.methods.deposit(acct_a, '1234').send({from: acct_a});
+
+    await expectRevert.unspecified(
+      rd.methods.distribute('1000').send({from: acct_a}),
+      'no deposit greater than 1 ELIGIBLE_UNIT'
+    );
+  });
+
+  it("does no distribution if stake becomes ineligible after withdrawl", async function() {
+    var amountDeposit = new BN('100').mul(TEN18);
+    var amountWithdraw = new BN('100').mul(TEN18).sub(new BN('10000'));
+
+    await rd.methods.deposit(acct_a, amountDeposit.toString()).send({from: acct_a});
+
+    tx = await rd.methods.withdrawStake(acct_a, amountWithdraw.toString()).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'StakeWithdrawalMade', {
+      to: acct_b,
+      value: amountWithdraw
+    });
+
+    await expectRevert.unspecified(
+      rd.methods.distribute('1000').send({from: acct_a}),
+      'no deposit greater than 1 ELIGIBLE_UNIT'
+    );
+
+    // stake of A is 10000 but because it is < ELIGIBLE_UNIT total stake
+    // should be zero
+    expect(
+      await rd.methods.getStake(acct_a).call({from: acct_a})
+    ).to.be.equal('10000');
+
+    expect(
+      await rd.methods.getStakeTotal().call({from: acct_a})
+    ).to.be.equal('0');
+  });
+
+  it('allocates all reward to a single staker and allow its withdrawl', async function() {
     var amountDeposit = new BN('100').mul(TEN18);
     var amountDistribute = new BN('200').mul(TEN18);
 
@@ -82,80 +149,87 @@ contract('RewardsDistributorWrapper', accounts => {
 
     tx = await rd.methods.distribute(amountDistribute.toString()).send({from: acct_a});
     expectEvent.inLogs(tx.events, 'DistributionMade', {
-      _from: acct_a,
       value: amountDistribute
     });
 
-    // all reward is allocated to the single staker
-    var currentReward = await rd.methods.getReward(acct_a).call({from: acct_a});
-    expect(new BN(currentReward)).to.be.bignumber.equal(amountDistribute);
+    expect (
+      await rd.methods.getReward(acct_a).call({from: acct_a})
+    ).to.be.equal(amountDistribute.toString())
 
     tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
     expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
-      _from: acct_a,
+      to: acct_a,
       value: amountDistribute
     });
 
-    currentReward = await rd.methods.getReward(acct_a).call({from: acct_a});
-    expect(new BN(currentReward)).to.be.bignumber.equal(new BN(0));
+    expect (
+      await rd.methods.getReward(acct_a).call({from: acct_a})
+    ).to.be.equal('0')
   });
 
- it("deposits A, deposits B, distributes, withdraws stake, distributes, gets reward", async function() {
-    var acct_a = accounts[1];
-    var acct_b = accounts[2];
+  it("allocates no reward to stake <= ELIGIBLE_UNIT", async function() {
+    await rd.methods.deposit(acct_a, String(10 ** 9)).send({from: acct_a});
+    await rd.methods.deposit(acct_b, String(100)).send({from: acct_a});
 
-    var depositA = new BN('100').mul(TEN18);
-    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
-
-    var depositB = new BN('300').mul(TEN18);
-    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
-
-    var distribute1 = new BN('400').mul(TEN18);
+    var distribute1 = new BN('100').mul(TEN18);
     await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
 
-    var stakeA = await rd.methods.getStake(acct_a).call({from: acct_a});
-    expect(new BN(stakeA)).to.be.bignumber.equal(depositA);
-    await rd.methods.withdrawAllStake(acct_a).send({from: acct_a});
+    // all reward goes to A
+    expect (
+      await rd.methods.getReward(acct_a).call({from: acct_a})
+    ).to.be.equal(distribute1.toString())
 
-    // a second distribution after A has withdrawn entirely
-    var distribute2 = new BN('900').mul(TEN18);
-    await rd.methods.distribute(distribute2.toString()).send({from: acct_a});
-
-    var rewardB = await rd.methods.getReward(acct_b).call({from: acct_a});
-    expect(new BN(rewardB)).to.be.bignumber.equal(new BN('1200').mul(TEN18));
+    expect (
+      await rd.methods.getReward(acct_b).call({from: acct_a})
+    ).to.be.equal('0')
   });
 
-  it("deposits A, deposits B, distributes and withdraws reward", async function() {
-    var acct_a = accounts[1];
-    var acct_b = accounts[2];
+ it("allocates 1st reward proportionally to 2 stakers and 2nd reward to remaining staker after the other withdrew", async function() {
+    var depositA = new BN(String(10 * 10 ** 9));  // 10 ELIGIBLE_UNITS
+    var depositB = new BN(String(30 * 10 ** 9));
+    var distribute1 = new BN('400');  // notice this is in wei
+    var distribute2 = new BN('900');
 
-    var depositA = new BN('100').mul(TEN18);
     await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
-
-    var depositB = new BN('300').mul(TEN18);
     await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
+    await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
 
+    // second distribution after A has withdrawn entirely
+    await rd.methods.withdrawAllStake(acct_a).send({from: acct_a});
+    await rd.methods.distribute(distribute2.toString()).send({from: acct_a});
+
+    expect (
+      await rd.methods.getReward(acct_b).call({from: acct_a})
+    ).to.be.equal('1200')
+
+    expect (
+      await rd.methods.getReward(acct_a).call({from: acct_a})
+    ).to.be.equal('100')
+  });
+
+  it("withdraws reward after proportional reward distribution", async function() {
+    var depositA = new BN('100').mul(TEN18);
+    var depositB = new BN('300').mul(TEN18);
     var distribute1 = new BN('40').mul(TEN18);
+
+    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
+    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
     await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
 
     tx = await rd.methods.withdrawReward(acct_b).send({from: acct_a});
     expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
-      _from: acct_b,
+      to: acct_b,
       value: new BN('30').mul(TEN18)
     });
   });
 
-  it("deposits A, deposits B, distributes X 2 and withdraws reward", async function() {
-    var acct_a = accounts[1];
-    var acct_b = accounts[2];
-
+  it("withdraws reward after two consecutive reward distributions", async function() {
     var depositA = new BN('100').mul(TEN18);
-    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
-
     var depositB = new BN('300').mul(TEN18);
-    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
-
     var distribute1 = new BN('400').mul(TEN18);
+
+    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
+    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
     await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
 
     var distribute2 = new BN('4000').mul(TEN18);
@@ -163,68 +237,159 @@ contract('RewardsDistributorWrapper', accounts => {
 
     tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
     expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
-      _from: acct_a,
+      to: acct_a,
       value: new BN('1100').mul(TEN18)
     });
 
     tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
     expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
-      _from: acct_a,
+      to: acct_a,
       value: new BN('0')
     });
 
     tx = await rd.methods.withdrawReward(acct_b).send({from: acct_a});
     expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
-      _from: acct_b,
+      to: acct_b,
       value: new BN('3300').mul(TEN18)
     });
   });
 
-  it("deposits A, distributes, deposits B, distributes and reads reward", async function() {
-    var acct_a = accounts[1];
-    var acct_b = accounts[2];
-
+  it("distributes after partial stake withdrawal and reads reward", async function() {
     var depositA = new BN('100').mul(TEN18);
-    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
-
-    var distribute1 = new BN('100').mul(TEN18);
-    await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
-
     var depositB = new BN('300').mul(TEN18);
-    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
-
-    var stakeTotal = await rd.methods.getStakeTotal().call({from: acct_a});
-    expect(new BN(stakeTotal)).to.be.bignumber.equal(new BN('400').mul(TEN18));
-
+    var distribute1 = new BN('100').mul(TEN18);
+    var withdrawB = new BN('200').mul(TEN18);
     var distribute2 = new BN('100').mul(TEN18);
-    await rd.methods.distribute(distribute2.toString()).send({from: acct_a});
 
-    var rewardA = await rd.methods.getReward(acct_a).call({from: acct_a});
-    expect(new BN(rewardA)).to.be.bignumber.equal(new BN('125').mul(TEN18));
-
-    var rewardB = await rd.methods.getReward(acct_b).call({from: acct_a});
-    expect(new BN(rewardB)).to.be.bignumber.equal(new BN('75').mul(TEN18));
-  });
-
-  it("handles magnitudes: A deposits 9999, B deposits 1, distribute, withdraw stake, distribute, withdraw reward", async function() {
-    var acct_a = accounts[1];
-    var acct_b = accounts[2];
-
-    var depositA = new BN('9999').mul(TEN18);
     await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
-
-    var depositB = new BN('1').mul(TEN18);
     await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
-
-    var distribute1 = new BN('1').mul(TEN18);
     await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
 
-    await rd.methods.withdrawAllStake(acct_a).send({from: acct_a});
+    tx = await rd.methods.withdrawStake(acct_b, withdrawB.toString()).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'StakeWithdrawalMade', {
+      to: acct_b,
+      value: withdrawB
+    });
 
-    var distribute2 = new BN('2').mul(TEN18);
     await rd.methods.distribute(distribute2.toString()).send({from: acct_a});
 
-    var rewardB = await rd.methods.getReward(acct_b).call({from: acct_a});
-    expect(new BN(rewardB)).to.be.bignumber.equal(new BN('2000100000000000000'));
+    expect(
+      await rd.methods.getStakeTotal().call({from: acct_a})
+    ).to.be.equal(String(200 * 10 ** 18));
+
+    expect (
+      await rd.methods.getReward(acct_a).call({from: acct_a})
+    ).to.be.equal(String(75 * 10 ** 18));
+
+    expect (
+      await rd.methods.getReward(acct_b).call({from: acct_a})
+    ).to.be.equal(String(125 * 10 ** 18));
   });
+
+  it("withdraws reward after stake has been withdrawn", async function() {
+    var depositA = new BN('100').mul(TEN18);
+    var distribute1 = new BN('10').mul(TEN18);
+
+    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
+    await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
+
+    tx = await rd.methods.withdrawStake(acct_a, depositA.toString()).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'StakeWithdrawalMade', {
+      to: acct_b,
+      value: depositA
+    });
+
+    tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      to: acct_a,
+      value: distribute1
+    });
+
+    expect(
+      await rd.methods.getStakeTotal().call({from: acct_a})
+    ).to.be.equal('0');
+  });
+
+  it("handles magnitude: A deposits 9999, B deposits 1, distribute, withdraw stake, distribute, withdraw reward", async function() {
+    var depositA = new BN('9999').mul(TEN18);
+    var depositB = new BN('1').mul(TEN18);
+    var distribute1 = new BN('1').mul(TEN18);
+    var distribute2 = new BN('2').mul(TEN18);
+
+    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
+    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
+
+    await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
+    await rd.methods.withdrawAllStake(acct_a).send({from: acct_a});
+    await rd.methods.distribute(distribute2.toString()).send({from: acct_a});
+
+    expect (
+      await rd.methods.getReward(acct_b).call({from: acct_a})
+    ).to.be.equal('2000100000000000000');
+  });
+
+  it("handles magnitude: deposit 10**6 10**9 10**12 10**15, distribute, withdraw reward", async function() {
+    await rd.methods.deposit(acct_a, String(10 ** 6)).send({from: acct_a});
+    await rd.methods.deposit(acct_b, String(10 ** 9)).send({from: acct_a});
+    await rd.methods.deposit(acct_c, String(10 ** 12)).send({from: acct_a});
+    // 10**6 is NOT substracted so B + C + D stakes sum up to 10 ** 15
+    await rd.methods.deposit(acct_d, String(10 ** 15 - 10 ** 12 - 10 ** 9)).send({from: acct_a});
+
+    await rd.methods.distribute(String(10 ** 9)).send({from: acct_a});
+
+    // A gets no reward because its stake is below ELIGIBLE_UNIT
+    expect (
+      await rd.methods.getReward(acct_a).call({from: acct_a})
+    ).to.be.equal('0');
+
+    expect (
+      await rd.methods.getReward(acct_b).call({from: acct_a})
+    ).to.be.equal('1000');
+
+    expect (
+      await rd.methods.getReward(acct_c).call({from: acct_a})
+    ).to.be.equal('1000000');
+
+    expect (
+      await rd.methods.getReward(acct_d).call({from: acct_a})
+    ).to.be.equal(String(10 ** 9 - 10 ** 6 - 10 ** 3));
+  });
+
+  it("carries reminder to second distribution and withdraws reward", async function() {
+    await rd.methods.deposit(acct_a, String(10 ** 9)).send({from: acct_a});
+    await rd.methods.deposit(acct_b, String(9 * 10 ** 9)).send({from: acct_a});
+
+    // 19 wei can not be divided to 10 ELIGIBLE_UNITS; So only 10 wei
+    // will be distributed and 9 will be stored as remainder and
+    // added to the next distribution
+    await rd.methods.distribute(String(19)).send({from: acct_a});
+
+    tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      to: acct_a,
+      value: 1
+    });
+
+    tx = await rd.methods.withdrawReward(acct_b).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      to: acct_b,
+      value: 9
+    });
+
+    // 9 wei reminder + 1 new wei can now be divided to 10 EILIGIBLE_UNITS
+    await rd.methods.distribute(String(1)).send({from: acct_a});
+
+    tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      to: acct_a,
+      value: 1
+    });
+
+    tx = await rd.methods.withdrawReward(acct_b).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      to: acct_b,
+      value: 9
+    });
+  });
+
 });

--- a/test/unit/rewardDistributor.spec.ts
+++ b/test/unit/rewardDistributor.spec.ts
@@ -149,6 +149,7 @@ contract('RewardsDistributorWrapper', accounts => {
 
     tx = await rd.methods.distribute(amountDistribute.toString()).send({from: acct_a});
     expectEvent.inLogs(tx.events, 'DistributionMade', {
+      from: 0,
       value: amountDistribute
     });
 

--- a/test/unit/rewardDistributor.spec.ts
+++ b/test/unit/rewardDistributor.spec.ts
@@ -356,7 +356,7 @@ contract('RewardsDistributorWrapper', accounts => {
     ).to.be.equal(String(10 ** 9 - 10 ** 6 - 10 ** 3));
   });
 
-  it("carries reminder to second distribution and withdraws reward", async function() {
+  it("carries remainder to second distribution and withdraws reward", async function() {
     await rd.methods.deposit(acct_a, String(10 ** 9)).send({from: acct_a});
     await rd.methods.deposit(acct_b, String(9 * 10 ** 9)).send({from: acct_a});
 
@@ -377,7 +377,7 @@ contract('RewardsDistributorWrapper', accounts => {
       value: 9
     });
 
-    // 9 wei reminder + 1 new wei can now be divided to 10 EILIGIBLE_UNITS
+    // 9 wei remainder + 1 new wei can now be divided to 10 EILIGIBLE_UNITS
     await rd.methods.distribute(String(1)).send({from: acct_a});
 
     tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});

--- a/test/unit/rewardDistributor.spec.ts
+++ b/test/unit/rewardDistributor.spec.ts
@@ -34,7 +34,24 @@ contract('RewardsDistributorWrapper', accounts => {
     expect(new BN(stakeTotal)).to.be.bignumber.equal(new BN(0));
   });
 
-  it('accepts deposit A, gets stake, withdraws all stake, gets stake again', async function() {
+  it("withdraws ZERO reward", async function() {
+    var acct_a = accounts[1];
+
+    tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      _from: acct_a,
+      value: new BN('0')
+    });
+  });
+
+  it("reads ZERO stake", async function() {
+    var acct_a = accounts[1];
+
+    let stake = await rd.methods.getStake(acct_a).call({from: acct_a});
+    expect(new BN(stake)).to.be.bignumber.equal(new BN('0'));
+  });
+
+  it('deposits A, gets stake, withdraws all stake, gets stake again', async function() {
     var acct_a = accounts[1];
     var amount = new BN('100').mul(TEN18);
 
@@ -56,7 +73,7 @@ contract('RewardsDistributorWrapper', accounts => {
     expect(new BN(stakeFinal)).to.be.bignumber.equal(new BN(0));
   });
 
-  it('deposit A, distribute, getReward, withdrawReward and getReward', async function() {
+  it('deposits A, distributes, gets Reward, withdraws Reward and gets Reward', async function() {
     var acct_a = accounts[1];
     var amountDeposit = new BN('100').mul(TEN18);
     var amountDistribute = new BN('200').mul(TEN18);
@@ -82,5 +99,132 @@ contract('RewardsDistributorWrapper', accounts => {
     currentReward = await rd.methods.getReward(acct_a).call({from: acct_a});
     expect(new BN(currentReward)).to.be.bignumber.equal(new BN(0));
   });
-    
+
+ it("deposits A, deposits B, distributes, withdraws stake, distributes, gets reward", async function() {
+    var acct_a = accounts[1];
+    var acct_b = accounts[2];
+
+    var depositA = new BN('100').mul(TEN18);
+    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
+
+    var depositB = new BN('300').mul(TEN18);
+    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
+
+    var distribute1 = new BN('400').mul(TEN18);
+    await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
+
+    var stakeA = await rd.methods.getStake(acct_a).call({from: acct_a});
+    expect(new BN(stakeA)).to.be.bignumber.equal(depositA);
+    await rd.methods.withdrawAllStake(acct_a).send({from: acct_a});
+
+    // a second distribution after A has withdrawn entirely
+    var distribute2 = new BN('900').mul(TEN18);
+    await rd.methods.distribute(distribute2.toString()).send({from: acct_a});
+
+    var rewardB = await rd.methods.getReward(acct_b).call({from: acct_a});
+    expect(new BN(rewardB)).to.be.bignumber.equal(new BN('1200').mul(TEN18));
+  });
+
+  it("deposits A, deposits B, distributes and withdraws reward", async function() {
+    var acct_a = accounts[1];
+    var acct_b = accounts[2];
+
+    var depositA = new BN('100').mul(TEN18);
+    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
+
+    var depositB = new BN('300').mul(TEN18);
+    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
+
+    var distribute1 = new BN('40').mul(TEN18);
+    await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
+
+    tx = await rd.methods.withdrawReward(acct_b).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      _from: acct_b,
+      value: new BN('30').mul(TEN18)
+    });
+  });
+
+  it("deposits A, deposits B, distributes X 2 and withdraws reward", async function() {
+    var acct_a = accounts[1];
+    var acct_b = accounts[2];
+
+    var depositA = new BN('100').mul(TEN18);
+    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
+
+    var depositB = new BN('300').mul(TEN18);
+    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
+
+    var distribute1 = new BN('400').mul(TEN18);
+    await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
+
+    var distribute2 = new BN('4000').mul(TEN18);
+    await rd.methods.distribute(distribute2.toString()).send({from: acct_a});
+
+    tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      _from: acct_a,
+      value: new BN('1100').mul(TEN18)
+    });
+
+    tx = await rd.methods.withdrawReward(acct_a).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      _from: acct_a,
+      value: new BN('0')
+    });
+
+    tx = await rd.methods.withdrawReward(acct_b).send({from: acct_a});
+    expectEvent.inLogs(tx.events, 'RewardWithdrawalMade', {
+      _from: acct_b,
+      value: new BN('3300').mul(TEN18)
+    });
+  });
+
+  it("deposits A, distributes, deposits B, distributes and reads reward", async function() {
+    var acct_a = accounts[1];
+    var acct_b = accounts[2];
+
+    var depositA = new BN('100').mul(TEN18);
+    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
+
+    var distribute1 = new BN('100').mul(TEN18);
+    await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
+
+    var depositB = new BN('300').mul(TEN18);
+    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
+
+    var stakeTotal = await rd.methods.getStakeTotal().call({from: acct_a});
+    expect(new BN(stakeTotal)).to.be.bignumber.equal(new BN('400').mul(TEN18));
+
+    var distribute2 = new BN('100').mul(TEN18);
+    await rd.methods.distribute(distribute2.toString()).send({from: acct_a});
+
+    var rewardA = await rd.methods.getReward(acct_a).call({from: acct_a});
+    expect(new BN(rewardA)).to.be.bignumber.equal(new BN('125').mul(TEN18));
+
+    var rewardB = await rd.methods.getReward(acct_b).call({from: acct_a});
+    expect(new BN(rewardB)).to.be.bignumber.equal(new BN('75').mul(TEN18));
+  });
+
+  it("handles magnitudes: A deposits 9999, B deposits 1, distribute, withdraw stake, distribute, withdraw reward", async function() {
+    var acct_a = accounts[1];
+    var acct_b = accounts[2];
+
+    var depositA = new BN('9999').mul(TEN18);
+    await rd.methods.deposit(acct_a, depositA.toString()).send({from: acct_a});
+
+    var depositB = new BN('1').mul(TEN18);
+    await rd.methods.deposit(acct_b, depositB.toString()).send({from: acct_a});
+
+    var distribute1 = new BN('1').mul(TEN18);
+    await rd.methods.distribute(distribute1.toString()).send({from: acct_a});
+
+    await rd.methods.withdrawAllStake(acct_a).send({from: acct_a});
+
+    var distribute2 = new BN('2').mul(TEN18);
+    await rd.methods.distribute(distribute2.toString()).send({from: acct_a});
+
+    var rewardB = await rd.methods.getReward(acct_b).call({from: acct_a});
+    expect(new BN(rewardB)).to.be.bignumber.equal(new BN('2000100000000000000'));
+  });
 });


### PR DESCRIPTION
Implements scalable pull-based dividends as an internal "library", based on:
 [1] http://batog.info/papers/scalable-reward-distribution.pdf
 [2] https://solmaz.io/2019/02/24/scalable-reward-changing

## Scope

Add a private "accounting" interface that is currently not linked to any ERC20 or eth transfers. Note that both the staked token and the awarded (dividend) token can be any of an ERC20 or eth. This integration will be added in a separate PR.

## Eligible Unit

If every staked `wei` were to count towards accruing dividends, then no distribution would be possible with amounts smaller than the total stake (if there are two stakers, one with `1 eth` and one with `1 wei` then any amount < `1 eth + 1 wei` can not be correctly allocated). Given that in most applications there will be a need to distribute smaller amounts than the total stake then we're introducing an "eligible unit" as is the smallest amount of stake that "matters" for accruing dividends. 

This value defaults now to `10**9` which is half the orders of magnitude a typical ERC20 contract would use as decimals. I find this a good compromise between smaller "wasted" reminders of individual deposits (say ELIGIBLE_UNIT=1 eth, anyone depositing smaller amounts would not receive any dividends) and ability to distribute smaller amounts (like in above example).

This default should be revisited in case the staked and the dividend token have largely different circulating supplies. Actually, it depends more on the expected volumes of stake and dividends tokens in the contract, but probably the total circulating supply is a good enough indicator.

## Distribution

Accepts any amount as an argument to `_distribute` even if not all amounts could possibly be distributed (if called with `1 wei` there's no way it could be allocated if total stake, in eligible units, is greater than 1). Smaller amounts that can not immediately be distributed are accumulated until distribution is possible, at a future `_distribute` call.

Currently calls to `_distribute` are reverted if there is no stake. Alternatively it could accumulate those amounts until at least one user stakes in.

## Withdrawal

Stake and dividend can be withdrawn independently. 

## Gas usage

Currently this implementation stores 3 `int256`s per address. One of them simply stores stake modulo ELIGIBLE_UNIT and could easily be eliminated at the expense of extra computation per call. Not sure which one is more gas efficient. Also, if this current version will be embedded into an ERC20, the total storage would be of 4 `int256` per address. It could be reduced to only 2, if `balanceOf`, `_stake` and `_stakeReminder` are unified. I leave that as a future improvement.

## Tests

  Contract: RewardsDistributorWrapper
    ✓ deploys and initializes
    ✓ withdraws ZERO reward (108ms)
    ✓ reads ZERO stake (68ms)
    ✓ reverts if trying to withdraw amount > stake (74ms)
    ✓ updates total stake after deposit > ELIGIBLE_UNIT (163ms)
    ✓ doesn't update total stake after deposit < ELIGIBLE_UNIT (92ms)
    ✓ deposits A, gets stake, withdraws all stake, gets stake again (199ms)
    ✓ does no distribution if no stake >= ELIGIBLE_UNIT (106ms)
    ✓ does no distribution if stake becomes ineligible after withdrawl (352ms)
    ✓ allocates all reward to a single staker and allow its withdrawl (242ms)
    ✓ allocates no reward to stake <= ELIGIBLE_UNIT (250ms)
    ✓ allocates 1st reward proportionally to 2 stakers and 2nd reward to remaining staker after the other withdrew (362ms)
    ✓ withdraws reward after proportional reward distribution (251ms)
    ✓ withdraws reward after two consecutive reward distributions (462ms)
    ✓ distributes after partial stake withdrawal and reads reward (481ms)
    ✓ withdraws reward after stake has been withdrawn (308ms)
    ✓ handles magnitude: A deposits 9999, B deposits 1, distribute, withdraw stake, distribute, withdraw reward (333ms)
    ✓ handles magnitude: deposit 10**6 10**9 10**12 10**15, distribute, withdraw reward (421ms)
    ✓ carries reminder to second distribution and withdraws reward (491ms)


  19 passing (8s)



